### PR TITLE
fix the issue reported by @XiangyunHuang at https://d.cosx.org/d/421249

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knitr
 Type: Package
 Title: A General-Purpose Package for Dynamic Report Generation in R
-Version: 1.28.1
+Version: 1.28.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Adam", "Vogt", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - The argument `error` of `include_graphics()` takes value from the global R option `knitr.graphics.error` by default, e.g., you may set `options(knitr.graphics.error = FALSE)` so `include_graphics()` won't signal an error if the graphics file to be included doesn't exist.
 
+## BUG FIXES
+
+- For non-R code chunks that generate plots and use the chunk option `fig.cap`, the `plot` hook in **knitr** stopped working in v1.27 and v1.28 (thanks, @XiangyunHuang, https://d.cosx.org/d/421249).
+
 # CHANGES IN knitr VERSION 1.28
 
 ## BUG FIXES

--- a/R/output.R
+++ b/R/output.R
@@ -563,6 +563,7 @@ wrap.knit_image_paths = function(x, options = opts_chunk$get(), inline = FALSE) 
     if (length(w1) * length(w2) == 1 && is.numeric(w1) && w1 == w2)
       options['out.width'] = list(NULL)
   }
+  options$fig.num = options$fig.num %n% length(x)
   dpi = attr(x, 'dpi') %n% options$dpi
   hook = knit_hooks$get('plot')
   paste(unlist(lapply(seq_along(x), function(i) {


### PR DESCRIPTION
the python engine was from reticulate, and knitr doesn't know when/whether the python code has generated plots, so the chunk option fig.num is empty, then this will error

  if (options$fig.num > 1)